### PR TITLE
removed combined texture samplers from DescriptorPool page info

### DIFF
--- a/src/slag/backends/dx12/DX12Backend.cpp
+++ b/src/slag/backends/dx12/DX12Backend.cpp
@@ -492,7 +492,6 @@ namespace slag
 
             poolSize += pageInfo.samplers;
             poolSize += pageInfo. sampledTextures;
-            poolSize += pageInfo. combinedSamplerTextures;
             poolSize += pageInfo. storageTextures;
             poolSize += pageInfo. uniformTexelBuffers;
             poolSize += pageInfo. storageTexelBuffers;

--- a/src/slag/backends/vulkan/core/VulkanDescriptorPool.cpp
+++ b/src/slag/backends/vulkan/core/VulkanDescriptorPool.cpp
@@ -86,6 +86,10 @@ namespace slag
 
             if (needReallocate)
             {
+                if (!_pageInfo.allowGrow)
+                {
+                    throw std::runtime_error("Unable to allocate bundle. Pool growth for this pool is not enabled, and maximum descriptors have been allocated for this pool");
+                }
                 if(_currentPage == _pages.size()-1)
                 {
                     page = allocatePage();
@@ -118,10 +122,6 @@ namespace slag
             if(_pageInfo.sampledTextures)
             {
                 sizes.push_back({VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,_pageInfo.sampledTextures});
-            }
-            if(_pageInfo.combinedSamplerTextures)
-            {
-                sizes.push_back({VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,_pageInfo.combinedSamplerTextures});
             }
             if(_pageInfo.storageTextures)
             {

--- a/src/slag/backends/vulkan/core/VulkanDescriptorPool.h
+++ b/src/slag/backends/vulkan/core/VulkanDescriptorPool.h
@@ -23,6 +23,7 @@ namespace slag
             std::vector<VkDescriptorPool> _pages;
             size_t _currentPage = 0;
             DescriptorPoolPageInfo _pageInfo;
+            bool allowGrow = true;
         };
     } // vulkan
 } // slag

--- a/src/slag/core/DescriptorPool.h
+++ b/src/slag/core/DescriptorPool.h
@@ -31,6 +31,8 @@ namespace slag
         uint32_t accelerationStructures=0;
         ///Number of descriptor bundle descriptors that can be created from the pool, may be ignored by underlying API
         uint32_t descriptorBundles=1000;
+        ///Allow the pool to grow if needed as descriptors are created, or if the limits given are hard limits
+        bool allowGrow = true;
 
     };
     ///Pool for which descriptors can be assigned via DescriptorBundles


### PR DESCRIPTION
fixed non-compilation, and provided a mechanism to prevent descriptor pool growth if desired